### PR TITLE
Feat: Add 200MA Tab with HWB Scanner Integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ RUN ( \
     echo "TZ=Asia/Tokyo" ; \
     echo "" ; \
     echo "15 6 * * 1-5 . /app/backend/cron-env.sh && /app/backend/run_job.sh fetch >> /app/logs/cron_error.log 2>&1" ; \
-    echo "28 6 * * 1-5 . /app/backend/cron-env.sh && /app/backend/run_job.sh generate >> /app/logs/cron_error.log 2>&1" \
+    echo "28 6 * * 1-5 . /app/backend/cron-env.sh && /app/backend/run_job.sh generate >> /app/logs/cron_error.log 2>&1" ; \
+    echo "# HWBスキャン（米国市場終了30分後）" ; \
+    echo "30 5 * * 2-6 . /app/backend/cron-env.sh && python -m backend.hwb_scanner_cli >> /app/logs/hwb.log 2>&1" \
 ) | crontab -
 
 # Create logs directory

--- a/backend/cron_job_hwb.sh
+++ b/backend/cron_job_hwb.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+LOG_DIR="/app/logs"
+mkdir -p $LOG_DIR
+
+echo "$(date): Starting HWB scan..." >> $LOG_DIR/hwb.log
+cd /app
+python -m backend.hwb_scanner_cli >> $LOG_DIR/hwb.log 2>&1
+echo "$(date): HWB scan completed" >> $LOG_DIR/hwb.log

--- a/backend/hwb_scanner.py
+++ b/backend/hwb_scanner.py
@@ -1,0 +1,677 @@
+import json
+import os
+import sqlite3
+from datetime import datetime, timedelta
+import pandas as pd
+import numpy as np
+import yfinance as yf
+from curl_cffi import requests
+import asyncio
+import concurrent.futures
+from typing import List, Dict, Set, Tuple, Optional
+import logging
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+import mplfinance as mpf
+from io import BytesIO
+import base64
+import warnings
+warnings.filterwarnings("ignore")
+
+logger = logging.getLogger(__name__)
+
+# 設定
+DB_PATH = "data/hwb_cache.db"
+RUSSELL3000_CACHE_DAYS = 7
+BATCH_SIZE = 20
+MAX_WORKERS = 5
+SETUP_LOOKBACK_DAYS = 60
+FVG_SEARCH_DAYS = 30
+SIGNAL_COOLING_PERIOD = 14
+
+# HWB戦略パラメータ
+PROXIMITY_PERCENTAGE = 0.05
+FVG_ZONE_PROXIMITY = 0.10
+BREAKOUT_THRESHOLD = 0.001
+MA_PERIOD = 200
+
+
+class HWBDatabaseManager:
+    """SQLiteデータベース管理（簡略版）"""
+
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        self.init_database()
+
+    def init_database(self):
+        """データベースの初期化"""
+        os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
+
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+
+            # Russell 3000銘柄テーブル
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS russell3000_symbols (
+                    symbol TEXT PRIMARY KEY,
+                    last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+
+            # 株価データテーブル
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS stock_data (
+                    symbol TEXT,
+                    date DATE,
+                    open REAL,
+                    high REAL,
+                    low REAL,
+                    close REAL,
+                    volume INTEGER,
+                    sma200 REAL,
+                    ema200 REAL,
+                    weekly_sma200 REAL,
+                    PRIMARY KEY (symbol, date)
+                )
+            ''')
+
+            # シグナル履歴テーブル
+            cursor.execute('''
+                CREATE TABLE IF NOT EXISTS signal_history (
+                    symbol TEXT,
+                    signal_date DATE,
+                    signal_type TEXT,
+                    score REAL,
+                    PRIMARY KEY (symbol, signal_date)
+                )
+            ''')
+
+            conn.commit()
+
+    def get_russell3000_symbols(self) -> Set[str]:
+        """Russell 3000銘柄リストを取得"""
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.cursor()
+
+            # キャッシュチェック
+            cursor.execute('''
+                SELECT symbol FROM russell3000_symbols
+                WHERE last_updated > datetime('now', '-7 days')
+            ''')
+
+            cached_symbols = {row[0] for row in cursor.fetchall()}
+
+            if cached_symbols:
+                logger.info(f"Russell 3000銘柄をDBから取得: {len(cached_symbols)}銘柄")
+                return cached_symbols
+
+            # 新規取得
+            symbols = self._fetch_russell3000_symbols()
+
+            if symbols:
+                cursor.execute('DELETE FROM russell3000_symbols')
+                cursor.executemany(
+                    'INSERT INTO russell3000_symbols (symbol) VALUES (?)',
+                    [(s,) for s in symbols]
+                )
+                conn.commit()
+
+            return symbols
+
+    def _fetch_russell3000_symbols(self) -> Set[str]:
+        """Russell 3000銘柄を取得"""
+        symbols = set()
+
+        try:
+            # S&P500を取得
+            sp500_url = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+            tables = pd.read_html(sp500_url)
+            sp500_symbols = tables[0]["Symbol"].str.replace(".", "-", regex=False).tolist()
+            symbols.update(sp500_symbols)
+
+            # NASDAQ100を追加
+            nasdaq100_url = "https://en.wikipedia.org/wiki/Nasdaq-100"
+            tables = pd.read_html(nasdaq100_url)
+            nasdaq_symbols = tables[4]["Ticker"].tolist() if len(tables) > 4 else []
+            symbols.update(nasdaq_symbols)
+
+            # 追加の主要銘柄
+            additional = ["PLTR", "SNOW", "COIN", "HOOD", "SOFI", "RIVN", "LCID"]
+            symbols.update(additional)
+
+            logger.info(f"取得した銘柄数: {len(symbols)}")
+            return symbols
+
+        except Exception as e:
+            logger.error(f"銘柄取得エラー: {e}")
+            # 最小限のリスト
+            return {"AAPL", "MSFT", "GOOGL", "AMZN", "NVDA", "META", "TSLA"}
+
+
+class HWBAnalyzer:
+    """HWB戦略分析クラス（HanaView版）"""
+
+    def __init__(self, db_manager: HWBDatabaseManager):
+        self.db = db_manager
+        self.session = requests.Session(impersonate="safari15_5")
+
+    def get_stock_data(self, symbol: str) -> Tuple[Optional[pd.DataFrame], Optional[pd.DataFrame]]:
+        """株価データ取得"""
+        try:
+            stock = yf.Ticker(symbol, session=self.session)
+
+            # 日足データ（6ヶ月）
+            df_daily = stock.history(period="6mo", interval="1d")
+            if df_daily.empty or len(df_daily) < 100:
+                return None, None
+
+            # 週足データ（2年）
+            df_weekly = stock.history(period="2y", interval="1wk")
+            if df_weekly.empty or len(df_weekly) < 52:
+                return None, None
+
+            # タイムゾーン除去
+            df_daily.index = df_daily.index.tz_localize(None)
+            df_weekly.index = df_weekly.index.tz_localize(None)
+
+            # 移動平均を計算
+            df_daily['SMA200'] = df_daily['Close'].rolling(window=min(200, len(df_daily)), min_periods=50).mean()
+            df_daily['EMA200'] = df_daily['Close'].ewm(span=min(200, len(df_daily)), min_periods=50, adjust=False).mean()
+            df_weekly['SMA200'] = df_weekly['Close'].rolling(window=min(200, len(df_weekly)), min_periods=50).mean()
+
+            # 週足SMAを日足に結合
+            df_daily['Weekly_SMA200'] = np.nan
+            df_daily['Weekly_Close'] = np.nan
+
+            for idx, row in df_weekly.iterrows():
+                if pd.notna(row['SMA200']):
+                    week_start = idx - pd.Timedelta(days=idx.weekday())
+                    week_end = week_start + pd.Timedelta(days=6)
+                    mask = (df_daily.index >= week_start) & (df_daily.index <= week_end)
+                    if mask.any():
+                        df_daily.loc[mask, 'Weekly_SMA200'] = row['SMA200']
+                        df_daily.loc[mask, 'Weekly_Close'] = row['Close']
+
+            df_daily['Weekly_SMA200'] = df_daily['Weekly_SMA200'].ffill()
+            df_daily['Weekly_Close'] = df_daily['Weekly_Close'].ffill()
+
+            return df_daily, df_weekly
+
+        except Exception as e:
+            logger.debug(f"データ取得エラー ({symbol}): {e}")
+            return None, None
+
+    def check_rule1(self, df_daily: pd.DataFrame, df_weekly: pd.DataFrame) -> bool:
+        """ルール①: トレンドチェック"""
+        if df_daily is None or df_weekly is None:
+            return False
+
+        latest = df_daily.iloc[-1]
+
+        # 週足条件
+        weekly_condition = (
+            pd.notna(latest.get('Weekly_SMA200')) and
+            pd.notna(latest.get('Weekly_Close')) and
+            latest['Weekly_Close'] > latest['Weekly_SMA200']
+        )
+
+        # 日足条件（どちらかのMAを上回る）
+        daily_condition = (
+            pd.notna(latest.get('SMA200')) and
+            pd.notna(latest.get('EMA200')) and
+            (latest['Close'] > latest['SMA200'] or latest['Close'] > latest['EMA200'])
+        )
+
+        return weekly_condition and daily_condition
+
+    def find_setups(self, df_daily: pd.DataFrame) -> List[Dict]:
+        """ルール②: セットアップ検出"""
+        setups = []
+
+        valid_data = df_daily[(df_daily['SMA200'].notna()) & (df_daily['EMA200'].notna())].tail(SETUP_LOOKBACK_DAYS)
+
+        for i in range(len(valid_data)):
+            row = valid_data.iloc[i]
+            zone_upper = max(row['SMA200'], row['EMA200'])
+            zone_lower = min(row['SMA200'], row['EMA200'])
+
+            # ゾーン内チェック
+            if (zone_lower <= row['Open'] <= zone_upper and
+                zone_lower <= row['Close'] <= zone_upper):
+
+                setups.append({
+                    'date': valid_data.index[i],
+                    'open': row['Open'],
+                    'close': row['Close'],
+                    'high': row['High'],
+                    'low': row['Low'],
+                    'sma200': row['SMA200'],
+                    'ema200': row['EMA200'],
+                    'zone_upper': zone_upper,
+                    'zone_lower': zone_lower
+                })
+
+        return setups
+
+    def detect_fvg(self, df_daily: pd.DataFrame, setup_date: pd.Timestamp) -> List[Dict]:
+        """ルール③: FVG検出"""
+        fvgs = []
+
+        try:
+            setup_idx = df_daily.index.get_loc(setup_date)
+        except KeyError:
+            return fvgs
+
+        search_end = min(setup_idx + FVG_SEARCH_DAYS, len(df_daily) - 1)
+
+        for i in range(setup_idx + 3, search_end + 1):
+            candle_1 = df_daily.iloc[i-2]
+            candle_2 = df_daily.iloc[i-1]
+            candle_3 = df_daily.iloc[i]
+
+            # Bullish FVG
+            gap = candle_3['Low'] - candle_1['High']
+
+            if gap > 0 and gap / candle_1['High'] > 0.001:
+                # MA近接チェック
+                if self._check_ma_proximity(candle_3, candle_1):
+                    fvgs.append({
+                        'formation_date': df_daily.index[i],
+                        'upper_bound': candle_3['Low'],
+                        'lower_bound': candle_1['High'],
+                        'gap_size': gap,
+                        'gap_percentage': gap / candle_1['High'] * 100
+                    })
+
+        return fvgs
+
+    def _check_ma_proximity(self, candle_3: pd.Series, candle_1: pd.Series) -> bool:
+        """MA近接条件チェック"""
+        if pd.isna(candle_3.get('SMA200')) or pd.isna(candle_3.get('EMA200')):
+            return False
+
+        # 条件A: 3本目の始値or終値がMA±5%以内
+        for price in [candle_3['Open'], candle_3['Close']]:
+            for ma in [candle_3['SMA200'], candle_3['EMA200']]:
+                if abs(price - ma) / ma <= PROXIMITY_PERCENTAGE:
+                    return True
+
+        # 条件B: FVGゾーン中心がMA±10%以内
+        fvg_center = (candle_1['High'] + candle_3['Low']) / 2
+        for ma in [candle_3['SMA200'], candle_3['EMA200']]:
+            if abs(fvg_center - ma) / ma <= FVG_ZONE_PROXIMITY:
+                return True
+
+        return False
+
+    def check_breakout(self, df_daily: pd.DataFrame, setup: Dict, fvg: Dict) -> Optional[Dict]:
+        """ルール④: ブレイクアウトチェック"""
+        setup_date = setup['date']
+        fvg_date = fvg['formation_date']
+
+        try:
+            setup_idx = df_daily.index.get_loc(setup_date)
+            fvg_idx = df_daily.index.get_loc(fvg_date)
+        except KeyError:
+            return None
+
+        # レジスタンス計算
+        resistance_start = setup_idx + 1
+        resistance_end = fvg_idx
+
+        if resistance_end <= resistance_start:
+            resistance_start = max(0, setup_idx - 10)
+            resistance_end = setup_idx + 1
+
+        resistance_high = df_daily.iloc[resistance_start:resistance_end]['High'].max()
+
+        # FVG下限チェック
+        post_fvg = df_daily.iloc[fvg_idx + 1:]
+        if len(post_fvg) > 0:
+            if post_fvg['Low'].min() < fvg['lower_bound']:
+                return None
+
+        # ブレイクアウトチェック（最新日のみ）
+        current = df_daily.iloc[-1]
+        if current['Close'] > resistance_high * (1 + BREAKOUT_THRESHOLD):
+            return {
+                'breakout_date': df_daily.index[-1],
+                'breakout_price': current['Close'],
+                'resistance_price': resistance_high,
+                'breakout_percentage': (current['Close'] / resistance_high - 1) * 100
+            }
+
+        return None
+
+    def create_chart_base64(self, symbol: str, df_daily: pd.DataFrame,
+                            signal_type: str = None, setup: Dict = None,
+                            fvg: Dict = None, breakout: Dict = None) -> str:
+        """チャートをBase64エンコード画像として生成"""
+        try:
+            # 表示期間（直近180日）
+            df_plot = df_daily.tail(180).copy()
+
+            if len(df_plot) < 20:
+                return None
+
+            # mplfinanceスタイル
+            mc = mpf.make_marketcolors(
+                up='green', down='red', edge='inherit',
+                wick={'up':'green', 'down':'red'}, volume='in'
+            )
+            s = mpf.make_mpf_style(marketcolors=mc, gridstyle=':', y_on_right=True)
+
+            # 追加プロット
+            apds = []
+
+            # 移動平均線
+            if 'SMA200' in df_plot.columns and not df_plot['SMA200'].isna().all():
+                apds.append(mpf.make_addplot(df_plot['SMA200'], color='#9370DB', width=2))
+
+            if 'EMA200' in df_plot.columns and not df_plot['EMA200'].isna().all():
+                apds.append(mpf.make_addplot(df_plot['EMA200'], color='purple', width=2))
+
+            if 'Weekly_SMA200' in df_plot.columns and not df_plot['Weekly_SMA200'].isna().all():
+                apds.append(mpf.make_addplot(df_plot['Weekly_SMA200'], color='blue', width=3))
+
+            # タイトル設定
+            title = f'{symbol} - HWB Analysis'
+            if signal_type == 's2_breakout':
+                title += ' [SIGNAL]'
+            elif signal_type == 's1_fvg':
+                title += ' [CANDIDATE]'
+
+            # チャート作成
+            fig, axes = mpf.plot(
+                df_plot, type='candle', style=s, volume=True,
+                addplot=apds if apds else None,
+                title=title, returnfig=True,
+                figsize=(10, 6), panel_ratios=(3, 1)
+            )
+
+            ax = axes[0]
+
+            # セットアップゾーンの描画
+            if setup and setup['date'] in df_plot.index:
+                setup_idx = df_plot.index.get_loc(setup['date'])
+                rect = patches.Rectangle(
+                    (setup_idx - 0.5, setup['zone_lower']),
+                    1, setup['zone_upper'] - setup['zone_lower'],
+                    linewidth=2, edgecolor='yellow', facecolor='yellow', alpha=0.3
+                )
+                ax.add_patch(rect)
+
+            # FVGゾーンの描画
+            if fvg and fvg['formation_date'] in df_plot.index:
+                fvg_idx = df_plot.index.get_loc(fvg['formation_date'])
+                rect = patches.Rectangle(
+                    (fvg_idx - 2.5, fvg['lower_bound']),
+                    3, fvg['gap_size'],
+                    linewidth=2, edgecolor='green', facecolor='green', alpha=0.3
+                )
+                ax.add_patch(rect)
+
+            # ブレイクアウトマーカー
+            if breakout and breakout['breakout_date'] in df_plot.index:
+                bo_idx = df_plot.index.get_loc(breakout['breakout_date'])
+                ax.scatter(
+                    bo_idx, breakout['breakout_price'] * 0.98,
+                    marker='^', color='blue', s=200, zorder=5
+                )
+                # レジスタンスライン
+                ax.axhline(
+                    y=breakout['resistance_price'],
+                    color='red', linestyle='--', alpha=0.5
+                )
+
+            # Base64エンコード
+            buf = BytesIO()
+            plt.savefig(buf, format='png', bbox_inches='tight', dpi=100)
+            buf.seek(0)
+            plt.close()
+
+            import base64
+            img_base64 = base64.b64encode(buf.read()).decode('utf-8')
+            return f"data:image/png;base64,{img_base64}"
+
+        except Exception as e:
+            logger.error(f"チャート生成エラー ({symbol}): {e}")
+            return None
+
+
+class HWBScanner:
+    """HWBスキャナーメインクラス"""
+
+    def __init__(self):
+        self.db = HWBDatabaseManager(DB_PATH)
+        self.analyzer = HWBAnalyzer(self.db)
+        self.signal_history = {}
+        self.recent_signals = {}
+
+    async def scan_all_symbols(self, progress_callback=None):
+        """全銘柄スキャン（非同期）"""
+        # Russell 3000銘柄を取得
+        symbols = list(self.db.get_russell3000_symbols())
+        total = len(symbols)
+
+        logger.info(f"スキャン開始: {total}銘柄")
+
+        monitoring_candidates = []
+        today_signals = []
+        all_charts = {}
+
+        # 進捗状況
+        processed = 0
+
+        # バッチ処理
+        for i in range(0, total, BATCH_SIZE):
+            batch = symbols[i:i + BATCH_SIZE]
+
+            # 並列処理
+            with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+                futures = []
+                for symbol in batch:
+                    futures.append(executor.submit(self._analyze_symbol, symbol))
+
+                for future in concurrent.futures.as_completed(futures):
+                    try:
+                        result = future.result(timeout=30)
+                        if result:
+                            if result['signal_type'] == 's2_breakout':
+                                today_signals.append(result)
+                            elif result['signal_type'] == 's1_fvg':
+                                monitoring_candidates.append(result)
+
+                            # チャートデータを保存
+                            if result.get('chart'):
+                                all_charts[result['symbol']] = result['chart']
+
+                    except Exception as e:
+                        logger.error(f"分析エラー: {e}")
+
+                    processed += 1
+
+                    # 進捗通知
+                    if progress_callback and processed % 10 == 0:
+                        await progress_callback(processed, total)
+
+            # CPU負荷軽減
+            await asyncio.sleep(0.1)
+
+        # 結果をスコア順にソート
+        monitoring_candidates.sort(key=lambda x: x.get('score', 0), reverse=True)
+        today_signals.sort(key=lambda x: x.get('score', 0), reverse=True)
+
+        # JSONデータ作成
+        result = {
+            'scan_date': datetime.now().strftime('%Y-%m-%d'),
+            'scan_time': datetime.now().strftime('%H:%M:%S'),
+            'total_scanned': total,
+            'summary': {
+                'monitoring_candidates': [s['symbol'] for s in monitoring_candidates],
+                'today_signals': [s['symbol'] for s in today_signals],
+                'recent_signals': self.recent_signals
+            },
+            'signals': today_signals[:20],  # 上位20件
+            'candidates': monitoring_candidates[:30],  # 上位30件
+            'charts': all_charts
+        }
+
+        return result
+
+    def _analyze_symbol(self, symbol: str) -> Optional[Dict]:
+        """個別銘柄分析"""
+        try:
+            # データ取得
+            df_daily, df_weekly = self.analyzer.get_stock_data(symbol)
+
+            if df_daily is None or df_weekly is None:
+                return None
+
+            # ルール①チェック
+            if not self.analyzer.check_rule1(df_daily, df_weekly):
+                return None
+
+            # ルール②セットアップ検出
+            setups = self.analyzer.find_setups(df_daily)
+            if not setups:
+                return None
+
+            # 各セットアップをチェック
+            for setup in setups:
+                # 冷却期間チェック
+                if not self._should_process(symbol, setup['date']):
+                    continue
+
+                # ルール③FVG検出
+                fvgs = self.analyzer.detect_fvg(df_daily, setup['date'])
+
+                for fvg in fvgs:
+                    # ルール④ブレイクアウトチェック
+                    breakout = self.analyzer.check_breakout(df_daily, setup, fvg)
+
+                    # スコア計算
+                    score = self._calculate_score(setup, fvg, breakout)
+
+                    if breakout:
+                        # シグナル発生
+                        chart = self.analyzer.create_chart_base64(
+                            symbol, df_daily, 's2_breakout', setup, fvg, breakout
+                        )
+
+                        return {
+                            'symbol': symbol,
+                            'signal_type': 's2_breakout',
+                            'score': score,
+                            'setup': {
+                                'date': setup['date'].strftime('%Y-%m-%d'),
+                                'zone_width': (setup['zone_upper'] - setup['zone_lower']) / setup['close']
+                            },
+                            'fvg': {
+                                'date': fvg['formation_date'].strftime('%Y-%m-%d'),
+                                'gap_percentage': fvg['gap_percentage']
+                            },
+                            'breakout': {
+                                'date': breakout['breakout_date'].strftime('%Y-%m-%d'),
+                                'percentage': breakout['breakout_percentage']
+                            },
+                            'chart': chart
+                        }
+                    elif fvg:
+                        # 監視候補
+                        chart = self.analyzer.create_chart_base64(
+                            symbol, df_daily, 's1_fvg', setup, fvg, None
+                        )
+
+                        return {
+                            'symbol': symbol,
+                            'signal_type': 's1_fvg',
+                            'score': score,
+                            'setup': {
+                                'date': setup['date'].strftime('%Y-%m-%d'),
+                                'zone_width': (setup['zone_upper'] - setup['zone_lower']) / setup['close']
+                            },
+                            'fvg': {
+                                'date': fvg['formation_date'].strftime('%Y-%m-%d'),
+                                'gap_percentage': fvg['gap_percentage']
+                            },
+                            'chart': chart
+                        }
+
+            return None
+
+        except Exception as e:
+            logger.debug(f"分析エラー ({symbol}): {e}")
+            return None
+
+    def _should_process(self, symbol: str, setup_date: pd.Timestamp) -> bool:
+        """冷却期間チェック"""
+        if symbol not in self.signal_history:
+            return True
+
+        last_signal = self.signal_history.get(symbol)
+        if last_signal:
+            days_elapsed = (datetime.now() - last_signal).days
+            return days_elapsed >= SIGNAL_COOLING_PERIOD
+
+        return True
+
+    def _calculate_score(self, setup: Dict, fvg: Dict, breakout: Optional[Dict]) -> int:
+        """スコア計算（0-100）"""
+        score = 0
+
+        # セットアップスコア（最大30点）
+        zone_width = (setup['zone_upper'] - setup['zone_lower']) / setup['close']
+        if zone_width < 0.005:
+            score += 30
+        elif zone_width < 0.01:
+            score += 20
+        else:
+            score += 10
+
+        # FVGスコア（最大40点）
+        if fvg['gap_percentage'] > 0.5:
+            score += 40
+        elif fvg['gap_percentage'] > 0.3:
+            score += 30
+        elif fvg['gap_percentage'] > 0.1:
+            score += 20
+        else:
+            score += 10
+
+        # ブレイクアウトスコア（最大30点）
+        if breakout:
+            if breakout['breakout_percentage'] > 1.0:
+                score += 30
+            elif breakout['breakout_percentage'] > 0.5:
+                score += 20
+            else:
+                score += 10
+
+        return min(score, 100)
+
+
+# エクスポート用関数
+async def run_hwb_scan(progress_callback=None):
+    """HWBスキャン実行"""
+    scanner = HWBScanner()
+    result = await scanner.scan_all_symbols(progress_callback)
+
+    # 結果をファイルに保存
+    output_path = 'data/hwb_signals.json'
+    os.makedirs('data', exist_ok=True)
+
+    # チャートデータを別途保存（サイズが大きいため）
+    charts = result.pop('charts', {})
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(result, f, indent=2, ensure_ascii=False)
+
+    # チャートは別ファイルに保存
+    charts_path = 'data/hwb_charts.json'
+    with open(charts_path, 'w', encoding='utf-8') as f:
+        json.dump(charts, f, ensure_ascii=False)
+
+    logger.info(f"スキャン結果を保存: {output_path}")
+
+    return result

--- a/backend/hwb_scanner_cli.py
+++ b/backend/hwb_scanner_cli.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""HWBスキャナーCLI実行用スクリプト"""
+
+import asyncio
+import sys
+import logging
+from backend.hwb_scanner import run_hwb_scan
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+
+async def main():
+    """メイン実行関数"""
+    print("HWBスキャン開始...")
+
+    try:
+        result = await run_hwb_scan()
+        print(f"スキャン完了: {len(result.get('signals', []))}件のシグナル検出")
+        return 0
+
+    except Exception as e:
+        print(f"エラー: {e}")
+        return 1
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    sys.exit(exit_code)

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,10 @@ from typing import Dict, Any, Optional
 # Import security manager
 from .security_manager import security_manager
 
+# 既存のインポートに追加
+from .hwb_scanner import run_hwb_scan
+import asyncio
+
 # Load environment variables from .env file
 load_dotenv()
 
@@ -277,6 +281,77 @@ async def send_notification(
         "sent": sent_count,
         "failed": failed_count
     }
+
+# 新しいAPIエンドポイントを追加
+
+@app.post("/api/hwb/scan")
+async def trigger_hwb_scan(current_user: str = Depends(get_current_user)):
+    """HWBスキャンを手動実行（管理者のみ）"""
+    try:
+        # 非同期でスキャン実行
+        result = await run_hwb_scan()
+
+        return {
+            "success": True,
+            "message": f"スキャン完了: {result['summary']['today_signals']}件のシグナル検出",
+            "scan_date": result['scan_date'],
+            "scan_time": result['scan_time']
+        }
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/api/hwb/data")
+def get_hwb_data(current_user: str = Depends(get_current_user)):
+    """HWBデータ取得"""
+    try:
+        # メインデータ読み込み
+        data_path = 'data/hwb_signals.json'
+        if not os.path.exists(data_path):
+            return {"error": "データが見つかりません。スキャンを実行してください。"}
+
+        with open(data_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+
+        # チャートデータ読み込み
+        charts_path = 'data/hwb_charts.json'
+        if os.path.exists(charts_path):
+            with open(charts_path, 'r', encoding='utf-8') as f:
+                charts = json.load(f)
+                data['charts'] = charts
+
+        return data
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/api/hwb/status")
+def get_hwb_status(current_user: str = Depends(get_current_user)):
+    """HWBスキャンステータス確認"""
+    try:
+        data_path = 'data/hwb_signals.json'
+        if os.path.exists(data_path):
+            # ファイルの最終更新時刻を取得
+            mtime = os.path.getmtime(data_path)
+            last_scan = datetime.fromtimestamp(mtime).strftime('%Y-%m-%d %H:%M:%S')
+
+            with open(data_path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+
+            return {
+                "has_data": True,
+                "last_scan": last_scan,
+                "total_scanned": data.get('total_scanned', 0),
+                "signals_count": len(data.get('signals', [])),
+                "candidates_count": len(data.get('candidates', []))
+            }
+        else:
+            return {
+                "has_data": False,
+                "message": "データがありません。スキャンを実行してください。"
+            }
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 # Mount the frontend directory to serve static files
 # This must come AFTER all API routes

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ httpx==0.25.2
 python-jose[cryptography]==3.3.0
 pywebpush==2.0.1
 cryptography==46.0.1
+mplfinance>=0.12.10b0

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,6 +46,7 @@
             <button class="tab-button" data-tab="sp500">SP500</button>
             <button class="tab-button" data-tab="indicators">指標</button>
             <button class="tab-button" data-tab="column">コラム</button>
+            <button class="tab-button" data-tab="hwb200">200MA</button>
         </div>
 
         <main id="dashboard-content">
@@ -70,6 +71,27 @@
             </div>
             <div id="indicators-content" class="tab-pane"></div>
             <div id="column-content" class="tab-pane"></div>
+            <div id="hwb200-content" class="tab-pane">
+                <div class="hwb-controls">
+                    <button id="hwb-scan-btn" class="hwb-action-btn">
+                        📡 スキャン実行
+                    </button>
+                    <button id="hwb-refresh-btn" class="hwb-action-btn">
+                        🔄 データ更新
+                    </button>
+                    <div id="hwb-status" class="hwb-status-info"></div>
+                </div>
+                <div id="hwb-loading" class="loading-container" style="display: none;">
+                    <p>スキャン中...</p>
+                    <div class="loading-spinner"></div>
+                    <div id="hwb-progress"></div>
+                </div>
+                <div id="hwb-content">
+                    <div class="card">
+                        <p>データがありません。「スキャン実行」ボタンをクリックしてください。</p>
+                    </div>
+                </div>
+            </div>
         </main>
     </div>
     <script src="https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js"></script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -770,3 +770,239 @@ body {
         opacity: 0;
     }
 }
+
+/* HWB 200MAタブスタイル */
+.hwb-controls {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    padding: 15px;
+    background-color: var(--card-background);
+    border-radius: 8px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 8px var(--shadow-color);
+}
+
+.hwb-action-btn {
+    padding: 10px 20px;
+    background-color: var(--tab-active-bg);
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: bold;
+    transition: all 0.3s;
+}
+
+.hwb-action-btn:hover {
+    background-color: #0d8a93;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 107, 107, 0.3);
+}
+
+.hwb-action-btn:disabled {
+    background-color: #ccc;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.hwb-status-info {
+    flex: 1;
+    text-align: right;
+    color: var(--text-secondary);
+    font-size: 0.9em;
+}
+
+.hwb-summary {
+    background-color: var(--card-background);
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 25px;
+    box-shadow: 0 4px 12px var(--shadow-color);
+}
+
+.hwb-summary h2 {
+    color: var(--tab-text);
+    font-size: 1.6em;
+    margin-bottom: 15px;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 10px;
+}
+
+.hwb-summary-section {
+    margin: 15px 0;
+    padding: 15px;
+    background-color: #f8f9fa;
+    border-radius: 5px;
+    border-left: 4px solid var(--tab-text);
+}
+
+.hwb-summary-section h3 {
+    color: var(--text-primary);
+    font-size: 1.2em;
+    margin-bottom: 10px;
+}
+
+.hwb-ticker-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.hwb-ticker {
+    background-color: white;
+    padding: 5px 12px;
+    border-radius: 20px;
+    font-weight: 600;
+    font-size: 0.95em;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    transition: all 0.3s;
+}
+
+.hwb-ticker:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.hwb-ticker.signal {
+    background-color: #d4edda;
+    color: #155724;
+    border: 1px solid #c3e6cb;
+}
+
+.hwb-ticker.candidate {
+    background-color: #d1ecf1;
+    color: #0c5460;
+    border: 1px solid #bee5eb;
+}
+
+.hwb-ticker.recent {
+    background-color: #fff3cd;
+    color: #856404;
+    border: 1px solid #ffeaa7;
+}
+
+.hwb-charts-section {
+    margin-top: 30px;
+}
+
+.hwb-charts-section h2 {
+    color: var(--tab-text);
+    font-size: 1.4em;
+    margin-bottom: 20px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.hwb-chart-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(500px, 1fr));
+    gap: 20px;
+}
+
+.hwb-chart-card {
+    background-color: var(--card-background);
+    border-radius: 8px;
+    padding: 15px;
+    box-shadow: 0 4px 12px var(--shadow-color);
+    transition: transform 0.3s;
+}
+
+.hwb-chart-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 20px var(--shadow-color);
+}
+
+.hwb-chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.hwb-chart-symbol {
+    font-size: 1.3em;
+    font-weight: bold;
+    color: var(--text-primary);
+}
+
+.hwb-chart-score {
+    padding: 4px 12px;
+    border-radius: 15px;
+    font-weight: 600;
+    font-size: 0.9em;
+}
+
+.hwb-chart-score.high {
+    background-color: #28a745;
+    color: white;
+}
+
+.hwb-chart-score.medium {
+    background-color: #ffc107;
+    color: #333;
+}
+
+.hwb-chart-score.low {
+    background-color: #6c757d;
+    color: white;
+}
+
+.hwb-chart-info {
+    display: flex;
+    gap: 15px;
+    margin: 10px 0;
+    font-size: 0.9em;
+    color: var(--text-secondary);
+}
+
+.hwb-chart-info span {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.hwb-chart-image {
+    width: 100%;
+    border-radius: 5px;
+    margin-top: 10px;
+}
+
+#hwb-progress {
+    margin-top: 20px;
+    background-color: #e0e0e0;
+    border-radius: 10px;
+    overflow: hidden;
+    height: 20px;
+}
+
+.hwb-progress-bar {
+    background-color: var(--tab-text);
+    height: 100%;
+    transition: width 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-size: 0.85em;
+}
+
+@media (max-width: 768px) {
+    .hwb-chart-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .hwb-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .hwb-status-info {
+        text-align: center;
+        margin-top: 10px;
+    }
+}


### PR DESCRIPTION
This change introduces a new '200MA' tab to the HanaView application, integrating the HWB-bot's alert functionality.

Key features include:
- A new backend scanner (`hwb_scanner.py`) that analyzes stocks based on the HWB strategy, generates charts, and saves the results.
- New API endpoints in `main.py` to trigger scans, fetch data, and get the status of the scanner.
- A new '200MA' tab in the frontend (`index.html`, `style.css`, `app.js`) that allows users to manually trigger scans and view the results, including detailed charts and summaries of signals and candidates.
- A cron job added to the `Dockerfile` to automate the daily execution of the HWB scan after the US market closes.
- Updated `requirements.txt` with necessary dependencies for chart generation (`mplfinance`, `matplotlib`).