### PR TITLE
feat: Implement single-ticker analysis in 200MA tab

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -73,19 +73,17 @@
             <div id="column-content" class="tab-pane"></div>
             <div id="hwb200-content" class="tab-pane">
                 <div class="hwb-controls">
-                    <button id="hwb-scan-btn" class="hwb-action-btn">
-                        📡 スキャン実行
-                    </button>
-                    <button id="hwb-refresh-btn" class="hwb-action-btn">
-                        🔄 データ更新
+                    <input type="text" id="hwb-ticker-input" class="hwb-ticker-input" placeholder="ティッカーを入力 (例: AAPL)">
+                    <button id="hwb-analyze-btn" class="hwb-action-btn">
+                        分析
                     </button>
                     <div id="hwb-status" class="hwb-status-info"></div>
                 </div>
                 <div id="hwb-loading" class="loading-container" style="display: none;">
-                    <p>スキャン中...</p>
+                    <p>分析中...</p>
                     <div class="loading-spinner"></div>
-                    <div id="hwb-progress"></div>
                 </div>
+                <div id="hwb-analysis-content"></div>
                 <div id="hwb-content">
                     <div class="card">
                         <p>データがありません。「スキャン実行」ボタンをクリックしてください。</p>


### PR DESCRIPTION
This commit introduces a new feature to the "200MA" tab, replacing the previous scan functionality with an on-demand, single-ticker analysis tool.

Changes:
- Backend:
  - Added a new function `analyze_single_ticker` to `hwb_scanner.py` to process individual stock symbols.
  - Exposed a new API endpoint `GET /api/hwb/analyze_ticker` in `main.py` to serve the analysis results.
- Frontend:
  - Modified `index.html` to replace the "Scan" button with a ticker input field and an "Analyze" button.
  - Updated `app.js` to implement the new UI logic, including fetching data from the new endpoint, displaying the analysis chart, and handling the "Analyze"/"Reset" button states.

This addresses the user's request to shift from a full scan to a more focused, user-driven analysis workflow.