### PR TITLE
Feat: Display Update Timestamp on 200MA Tab

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -319,9 +319,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.summaryData = await response.json();
                 this.render();
 
-                const { scan_date, summary } = this.summaryData;
+                const { updated_at, summary } = this.summaryData;
+                const displayDate = updated_at ? formatDateForDisplay(updated_at) : this.summaryData.scan_date;
                 this.showStatus(
-                    `最終スキャン: ${scan_date} | シグナル: ${summary.signals_count} | 候補: ${summary.candidates_count}`,
+                    `最終更新: ${displayDate} | シグナル: ${summary.signals_count} | 候補: ${summary.candidates_count}`,
                     'info'
                 );
 
@@ -341,13 +342,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         renderSummary(container) {
-            const { scan_date, scan_time, total_scanned, summary } = this.summaryData;
+            const { updated_at, scan_date, scan_time, total_scanned, summary } = this.summaryData;
             const summaryDiv = document.createElement('div');
             summaryDiv.className = 'hwb-summary';
+            const displayDate = updated_at ? formatDateForDisplay(updated_at) : `${scan_date} ${scan_time}`;
+
             summaryDiv.innerHTML = `
                 <h2>🤖 AI判定システム - HWB Strategy</h2>
                 <div class="scan-info">
-                    スキャン日時: ${scan_date} ${scan_time} | 処理銘柄: ${total_scanned}
+                    データ更新: ${displayDate} | 処理銘柄: ${total_scanned}
                 </div>
                 <div class="hwb-summary-grid">
                     <div>


### PR DESCRIPTION
This commit introduces a feature to display the data update timestamp on the 200MA tab, making it consistent with the other tabs in the application.

Key changes:
- **Backend (`main.py`):**
  - The `/api/hwb/daily/latest` endpoint now includes an `updated_at` field in its response. This field contains the ISO-formatted UTC timestamp of the last modification time of the `latest.json` data file.
  - Enhanced error logging by adding `traceback.print_exc()` to provide more detailed error information for data-fetching endpoints.

- **Frontend (`app.js`):**
  - The `HWB200MAManager` now utilizes the new `updated_at` field to display the data update time.
  - The status message and the main summary view on the 200MA tab now show "データ更新" (Data Updated) followed by the formatted timestamp.
  - If the `updated_at` field is not available, the frontend gracefully falls back to displaying the `scan_date`.