### PR TITLE
Fix Russell 3000 data fetching and extend analysis period

### DIFF
--- a/backend/hwb_scanner.py
+++ b/backend/hwb_scanner.py
@@ -44,7 +44,8 @@ class HWBAnalyzer:
     def find_setups(self, df_daily: pd.DataFrame) -> List[Dict]:
         """Rule ②: Setup Detection"""
         setups = []
-        valid_data = df_daily[df_daily['sma200'].notna() & df_daily['ema200'].notna()].tail(SETUP_LOOKBACK_DAYS)
+        # `.tail(SETUP_LOOKBACK_DAYS)` is removed to scan the entire history
+        valid_data = df_daily[df_daily['sma200'].notna() & df_daily['ema200'].notna()]
         for i in range(len(valid_data)):
             row = valid_data.iloc[i]
             zone_upper = max(row['sma200'], row['ema200'])


### PR DESCRIPTION
- Modified `hwb_data_manager.py` to fetch the Russell 3000 symbol list from the iShares ETF (IWV) holdings CSV instead of Wikipedia, resolving the 403 error.
- The new fetching logic tries to get the most recent data and handles cases where the data for a specific day is not available.
- Removed the fallback mechanism for symbol fetching as requested. If fetching fails, an error is logged, and an empty set is returned.
- Modified `hwb_scanner.py` to remove the 60-day lookback limit (`SETUP_LOOKBACK_DAYS`) when searching for setups.
- The scanner will now analyze the entire cached history (10 years) to identify all past signals, fulfilling the user's requirement.