### PR TITLE
feat: Update lightweight-charts to v5 API

### DIFF
--- a/frontend/rectangle-plugin.js
+++ b/frontend/rectangle-plugin.js
@@ -1,71 +1,94 @@
 /**
- * A more robust lightweight-charts primitive for drawing a rectangle on the chart.
- * This version is based on official examples and best practices.
+ * lightweight-charts v5対応 Rectangle Primitive
+ * Series Primitive として実装
  */
 class RectanglePrimitive {
     constructor(options) {
         this._options = options;
         this._source = null;
-        this._x1 = null;
-        this._y1 = null;
-        this._x2 = null;
-        this._y2 = null;
+        this._requestUpdate = null;
     }
 
-    attached(source) {
-        this._source = source;
+    attached(param) {
+        this._source = param;
+        this._requestUpdate = param.requestUpdate;
     }
 
     detached() {
         this._source = null;
+        this._requestUpdate = null;
     }
 
     paneViews() {
-        return [this];
+        return [new RectanglePaneView(this._options, this._source)];
     }
 
     updateAllViews() {
+        // 必要に応じて更新をリクエスト
+    }
+}
+
+class RectanglePaneView {
+    constructor(options, source) {
+        this._options = options;
+        this._source = source;
+    }
+
+    update() {
+        // ビューの更新
+    }
+
+    renderer() {
+        return new RectanglePaneRenderer(this._options, this._source);
+    }
+
+    zOrder() {
+        return 'normal';
+    }
+}
+
+class RectanglePaneRenderer {
+    constructor(options, source) {
+        this._options = options;
+        this._source = source;
+    }
+
+    draw(target) {
         if (!this._source) return;
 
-        const { chart, series } = this._source;
+        const { series, chart } = this._source;
         const timeScale = chart.timeScale();
         const priceScale = series.priceScale();
 
         const p1 = this._options.points[0];
         const p2 = this._options.points[1];
 
-        // Convert time and price to canvas coordinates
-        this._x1 = timeScale.timeToCoordinate(p1.time);
-        this._y1 = priceScale.priceToCoordinate(p1.price);
-        this._x2 = timeScale.timeToCoordinate(p2.time);
-        this._y2 = priceScale.priceToCoordinate(p2.price);
-    }
+        // 座標変換
+        const x1 = timeScale.timeToCoordinate(p1.time);
+        const y1 = priceScale.priceToCoordinate(p1.price);
+        const x2 = timeScale.timeToCoordinate(p2.time);
+        const y2 = priceScale.priceToCoordinate(p2.price);
 
-    renderer() {
-        return this;
-    }
+        if (x1 === null || x2 === null || y1 === null || y2 === null) {
+            return;
+        }
 
-    draw(target) {
         target.useBitmapCoordinateSpace(scope => {
-            if (this._x1 === null || this._x2 === null || this._y1 === null || this._y2 === null) {
-                return; // Don't draw if coordinates are not ready
-            }
             const ctx = scope.context;
-            const x = Math.min(this._x1, this._x2);
-            const y = Math.min(this._y1, this._y2);
-            const width = Math.abs(this._x1 - this._x2);
-            const height = Math.abs(this._y1 - this._y2);
+            const scaledX = Math.min(x1, x2) * scope.horizontalPixelRatio;
+            const scaledY = Math.min(y1, y2) * scope.verticalPixelRatio;
+            const scaledWidth = Math.abs(x1 - x2) * scope.horizontalPixelRatio;
+            const scaledHeight = Math.abs(y1 - y2) * scope.verticalPixelRatio;
 
-            // Draw the rectangle
+            // 塗りつぶし
             ctx.fillStyle = this._options.fillColor || 'rgba(255, 215, 0, 0.2)';
-            ctx.fillRect(x, y, width, height);
+            ctx.fillRect(scaledX, scaledY, scaledWidth, scaledHeight);
 
-            // Draw the border
-            const borderWidth = this._options.borderWidth || 0;
-            if (borderWidth > 0) {
+            // 境界線
+            if (this._options.borderWidth > 0) {
                 ctx.strokeStyle = this._options.borderColor || '#FFD700';
-                ctx.lineWidth = borderWidth;
-                ctx.strokeRect(x, y, width, height);
+                ctx.lineWidth = this._options.borderWidth * scope.horizontalPixelRatio;
+                ctx.strokeRect(scaledX, scaledY, scaledWidth, scaledHeight);
             }
         });
     }


### PR DESCRIPTION
Updates the frontend application to use the new API introduced in lightweight-charts v5.0.

- Replaces `chart.addCandlestickSeries()` and `chart.addLineSeries()` with the new `chart.addSeries(LightweightCharts.SeriesType, ...)` syntax in `frontend/app.js`.
- Replaces the old `rectangle-plugin.js` with a new implementation based on the v5 Series Primitives API to correctly render zones on the charts.
- Updates all chart rendering logic in both the global `renderLightweightChart` function and the `HWB200MAManager.renderLightweightChart` method to be compatible with the new library version.