### PR TITLE
Fix errors in HWB scanner CLI

### DIFF
--- a/backend/hwb_scanner.py
+++ b/backend/hwb_scanner.py
@@ -233,7 +233,7 @@ class HWBAnalyzer:
         # FVG違反チェック（FVG形成後に下限を大きく割り込んだら無効）
         post_fvg_data = df_daily.iloc[fvg_idx:]
         if post_fvg_data['low'].min() < fvg['lower_bound'] * 0.98:
-            return {'status': 'violated', 'violated_date': df_daily.index[post_fvg_data['low'].idxmin()]}
+            return {'status': 'violated', 'violated_date': post_fvg_data['low'].idxmin()}
 
         # 🔥 重要: FVG形成日から現在まで、各日でブレイクアウトをチェック
         vol_ma = df_daily['volume'].rolling(20).mean()


### PR DESCRIPTION
This commit addresses two separate errors that occurred during the execution of the HWB scanner.

1.  **Fix `IndexError` in `hwb_scanner.py`**: Corrected an `IndexError` that happened when identifying a violation date. The code was incorrectly trying to use a timestamp returned by `idxmin()` as an index into the DataFrame's index object. The fix uses the timestamp directly, which is the correct value.

2.  **Fix `TypeError` in `hwb_data_manager.py`**: Resolved a `TypeError: Object of type Timestamp is not JSON serializable` by implementing a robust `CustomJSONEncoder`. This encoder handles `pandas.Timestamp`, `numpy` data types, and other non-standard objects by converting them to JSON-compatible formats. The encoder is now used in all functions that write to JSON, making the data saving process more resilient.