### PR TITLE
feat: 200MAチャートの表示を改善

### DIFF
--- a/backend/hwb_scanner.py
+++ b/backend/hwb_scanner.py
@@ -817,7 +817,7 @@ class HWBScanner:
                         }
                         markers.append({
                             "time": middle_candle_date.strftime('%Y-%m-%d'),
-                            "position": "aboveBar",
+                            "position": "inBar",
                             "color": color_map.get(fvg.get('status'), '#FFD700'),
                             "shape": "circle",
                             "text": "🐮"


### PR DESCRIPTION
ユーザーの要望に基づき、200MAタブのチャート表示に関する複数の点を改善しました。

主な変更点:
- チャートのデフォルト表示期間を、最新シグナルの前後3ヶ月に設定
- SMA/EMAラインを非表示化
- 出来高チャートの表示マージンを調整
- FVGマーカーの表示位置をローソク足上に変更

これにより、チャートの視認性と分析のしやすさが向上します。

`frontend/app.js`にて、Lightweight Chartsの表示オプションと期間設定ロジックを修正しました。 `backend/hwb_scanner.py`にて、マーカーの`position`プロパティを`inBar`に変更しました。