### PR TITLE
feat: Implement dual-PIN auth and notification filtering

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ WORKDIR /app
 # Set the timezone to Japan Standard Time at the very beginning
 ENV TZ=Asia/Tokyo
 
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install system dependencies including tzdata for timezone support
 RUN apt-get update && apt-get install -y \
     cron \


### PR DESCRIPTION
This commit expands the dual-PIN authentication system to control both UI visibility and push notification delivery.

Key changes:

- Backend (`main.py`):
  - The `/api/auth/verify` endpoint now recognizes a standard PIN (123456) and a secret PIN (555555), returning a `permission` level ('standard' or 'secret') in the JWT and response.
  - The `/api/subscribe` endpoint now requires the main auth token and saves the user's `permission` level with their push subscription details.

- Frontend (`app.js`):
  - The `AuthManager` now stores the `permission` level in localStorage.
  - A new `applyTabPermissions` function hides the "200MA" tab for 'standard' users.
  - The subscription request now sends the main auth token to associate permissions.

- Notification Logic (`data_fetcher.py`):
  - The `send_push_notifications` method now filters recipients for "hwb-scan" (200MA) notifications, sending them only to users with 'secret' permission.

- Dockerfile:
  - Added `ENV DEBIAN_FRONTEND=noninteractive` to fix Docker build hangs caused by interactive prompts.