### PR TITLE
feat: Display MA lines on 200MA charts without labels

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -634,6 +634,27 @@ renderLightweightChart(container, symbolData, width, height) {
         volumeSeries.setData(chartData.volume);
     }
 
+    // --- MOVING AVERAGES ---
+    const maLines = [
+        { data: chartData.sma200, color: '#4a90e2', title: 'SMA 200' },
+        { data: chartData.ema200, color: '#f5a623', title: 'EMA 200' },
+        { data: chartData.weekly_sma200, color: '#d0021b', title: 'Weekly SMA 200' }
+    ];
+
+    maLines.forEach(ma => {
+        if (ma.data && ma.data.length > 0) {
+            const maSeries = chart.addSeries(LightweightCharts.LineSeries, {
+                color: ma.color,
+                lineWidth: 2,
+                title: ma.title,
+                // ラベルを非表示にするための設定
+                priceLineVisible: false,
+                lastValueVisible: false,
+            });
+            maSeries.setData(ma.data);
+        }
+    });
+
     // マーカー（FVGは🐮、ブレイクアウトはマゼンタで"Break"）
     if (chartData.markers && chartData.markers.length > 0) {
         LightweightCharts.createSeriesMarkers(candleSeries, chartData.markers);


### PR DESCRIPTION
This commit modifies the frontend to render the daily 200SMA, 200EMA, and weekly 200SMA lines on the 200MA tab charts, as per the user's request.

- Adds logic to `frontend/app.js` in the `renderLightweightChart` function to create and display the moving average line series.
- Sets the `priceLineVisible: false` and `lastValueVisible: false` options for each line series to hide their descriptive labels on the price scale.
- The lines are now visible, but the chart remains clean without the text labels.