### PR TITLE
feat: Implement secure dual-PIN auth and notification filtering

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,7 +54,7 @@ async def startup_event():
 
 # --- Configuration ---
 AUTH_PIN = os.getenv("AUTH_PIN", "123456")
-SECRET_PIN = os.getenv("SECRET_PIN", "555555")  # 新しいシークレットPIN
+SECRET_PIN = os.getenv("SECRET_PIN")  # デフォルト値を削除
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_DAYS = int(os.getenv("JWT_ACCESS_TOKEN_EXPIRE_DAYS", 30))
 NOTIFICATION_TOKEN_NAME = "notification_token"
@@ -176,7 +176,8 @@ def verify_pin(pin_data: PinVerification, response: Response, request: Request):
     permission = None
     if pin_data.pin == AUTH_PIN:
         permission = "standard"
-    elif pin_data.pin == SECRET_PIN:
+    # SECRET_PINが.envで設定されている場合のみ、シークレットPINの検証を行う
+    elif SECRET_PIN and pin_data.pin == SECRET_PIN:
         permission = "secret"
 
     if permission:


### PR DESCRIPTION
This commit introduces a comprehensive two-tiered authentication system using a standard PIN and an optional, environment-configured secret PIN. This system controls access to both UI features and push notifications.

Key changes:

- Backend (`main.py`):
  - Implemented a dual-PIN system. The standard PIN (`123456`) grants 'standard' permission.
  - The secret PIN is now loaded from the `SECRET_PIN` environment variable without a default value. If not set, the secret access path is disabled.
  - The `/api/auth/verify` endpoint returns a `permission` level ('standard' or 'secret') in the JWT and response.
  - The `/api/subscribe` endpoint saves the user's `permission` level with their push subscription.

- Frontend (`app.js`):
  - The `AuthManager` stores the `permission` level in localStorage.
  - The `applyTabPermissions` function dynamically hides the "200MA" tab for 'standard' users.
  - The subscription request now sends the main auth token to associate permissions.

- Notification Logic (`data_fetcher.py`):
  - The `send_push_notifications` method filters "hwb-scan" (200MA) notifications, sending them only to users with 'secret' permission.

- Dockerfile:
  - Added `ENV DEBIAN_FRONTEND=noninteractive` to prevent interactive prompts from `apt-get` during Docker builds, ensuring build stability.