### PR TITLE
fix(cron): Ensure HWB scanner runs from the correct directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY start.sh /app/start.sh
 # Make scripts executable
 RUN chmod +x /app/start.sh
 RUN chmod +x /app/backend/run_job.sh
+RUN chmod +x /app/backend/cron_job_hwb.sh
 
 # Add cron job with explicit timezone
 # Important: Include TZ in the crontab itself
@@ -43,7 +44,7 @@ RUN ( \
     echo "" ; \
     echo "15 6 * * 1-5 . /app/backend/cron-env.sh && /app/backend/run_job.sh fetch >> /app/logs/cron_error.log 2>&1" ; \
     echo "28 6 * * 1-5 . /app/backend/cron-env.sh && /app/backend/run_job.sh generate >> /app/logs/cron_error.log 2>&1" ; \
-    echo "35 6 * * 1-5 . /app/backend/cron-env.sh && python -m backend.hwb_scanner_cli >> /app/logs/hwb.log 2>&1" \
+    echo "35 6 * * 1-5 . /app/backend/cron-env.sh && /app/backend/cron_job_hwb.sh >> /app/logs/cron_error.log 2>&1" \
 ) | crontab -
 
 # Create logs directory


### PR DESCRIPTION
The cron job for the HWB scanner (`python -m backend.hwb_scanner_cli`) was failing because it was being executed from the default cron working directory (`/root`) instead of the application directory (`/app`). This resulted in a `ModuleNotFoundError` as the Python interpreter could not locate the `backend` module.

This commit resolves the issue by modifying the cron job in the `Dockerfile` to execute the existing wrapper script `/app/backend/cron_job_hwb.sh`. This script correctly changes the directory to `/app` before running the scanner, mirroring the behavior of other functional cron jobs in the system.

Additionally, the `Dockerfile` is updated to grant execute permissions to `/app/backend/cron_job_hwb.sh` to ensure it can be run by cron.