### PR TITLE
feat: Add Stage1+2 analysis tab and features

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1032,6 +1032,11 @@ renderLightweightChart(container, symbolData, width, height) {
                 const timeScale = chart.timeScale();
                 const chartWidth = container.clientWidth;
 
+                // Dynamically find the main price pane's canvas height
+                const mainPane = container.querySelector('tr:first-child .chart-markup-table canvas');
+                if (!mainPane) return;
+                const mainPaneHeight = mainPane.clientHeight;
+
                 if (!details.stage_history || details.stage_history.length === 0) return;
 
                 for (let i = 0; i < details.stage_history.length; i++) {
@@ -1052,11 +1057,12 @@ renderLightweightChart(container, symbolData, width, height) {
                         rect.className = 'stage-rect';
                         rect.style.left = `${left}px`;
                         rect.style.width = `${width}px`;
+                        rect.style.height = `${mainPaneHeight}px`; // Apply dynamic height
                         rect.style.backgroundColor = stageColors[segment.stage] || 'transparent';
 
                         const label = document.createElement('span');
                         label.className = 'stage-label';
-                        label.textContent = `Stage ${segment.stage}`;
+                        label.textContent = `第${segment.stage}ステージ`; // Localized label
                         rect.appendChild(label);
 
                         stageOverlay.appendChild(rect);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1296,7 +1296,6 @@ body {
 .stage-rect {
     position: absolute;
     top: 30px; /* Below chart title */
-    height: calc(50% - 30px); /* Main pane height approximation */
     display: flex;
     align-items: flex-start;
     justify-content: center;


### PR DESCRIPTION
This commit introduces the 'Stage1+2' analysis feature, a new tab in the HanaView application that displays detailed charts and information for stocks identified as being in market Stage 1 or 2.

Key changes include:

- **Authentication**:
  - A new `URA_PIN` is introduced, granting a 'ura' permission level with access to all application features, including the new tab.
  - The authentication logic in `main.py` and the permission handling in `app.js` have been updated accordingly.

- **Backend Service**:
  - The logic from the monolithic `stage.py` script has been refactored into a reusable `StageAnalyzerService` for better modularity and maintainability.
  - New API endpoints have been added to `main.py`:
    - `/api/stage/latest`: Provides a summary of stocks that are candidates for Stage 1 or 2.
    - `/api/stage/symbol/{symbol}`: Returns detailed analysis and chart data for a single stock.

- **Automation and Notifications**:
  - A cron job (`cron_job_stage.sh`) has been created to run the analysis pipeline automatically at 8:00 AM on weekdays.
  - The `Dockerfile` has been updated to install and schedule this cron job.
  - A notification system was implemented to send push notifications to users with the 'ura' permission level upon completion of the analysis.

- **Frontend Implementation**:
  - The "Stage1+2" tab has been added to `index.html`.
  - A new `Stage12Manager` class in `app.js` handles the fetching and rendering of data for the new tab.
  - A detailed view is implemented, featuring a specialized chart that includes:
    - Multiple moving averages (9-EMA, 21-EMA, 50-SMA, 200-SMA).
    - A custom overlay to display colored background regions corresponding to the market stage of the stock.
  - CSS has been added in `style.css` to support all new UI components.

- **Fixes**:
  - Corrected a chart rendering issue by dynamically calculating the height of the chart's price pane for the stage overlay instead of using a hardcoded CSS value.
  - Localized chart labels to Japanese.