### PR TITLE
Fix swipe navigation to respect tab permissions

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1276,8 +1276,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const touchendX = e.changedTouches[0].screenX;
             const deltaX = touchendX - touchstartX;
             if (Math.abs(deltaX) > horizontalSwipeThreshold) {
-                const tabButtons = Array.from(document.querySelectorAll('.tab-button'));
+                const tabButtons = Array.from(document.querySelectorAll('.tab-button'))
+                    .filter(btn => btn.style.display !== 'none');
                 const currentIndex = tabButtons.findIndex(b => b.classList.contains('active'));
+
+                if (currentIndex === -1) return; // Active tab not found among visible tabs
+
                 let nextIndex = (deltaX > 0) ? currentIndex - 1 : currentIndex + 1;
                 if (nextIndex < 0) {
                     nextIndex = tabButtons.length - 1;


### PR DESCRIPTION
The previous implementation of swipe navigation did not account for hidden tabs based on user permissions. This allowed users to swipe to and view restricted tabs.

This commit modifies the `initSwipeNavigation` function in `frontend/app.js` to filter for visible tabs before calculating the next tab index. This ensures that swiping only navigates between the tabs that are accessible to the current user.

- For 'standard' PIN users, swiping right from the 'Column' tab now correctly navigates to the 'Market' tab, skipping the hidden '200MA' and 'Stage1+2' tabs.
- For 'secret' PIN users, swiping right from the '200MA' tab now correctly navigates to the 'Market' tab, skipping the hidden 'Stage1+2' tab.