### PR TITLE
feat: Redesign HWB summary and ticker analysis UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -75,18 +75,17 @@
                 <div class="hwb-controls">
                     <input type="text" id="hwb-ticker-input" class="hwb-ticker-input" placeholder="ティッカーを入力 (例: AAPL)">
                     <button id="hwb-analyze-btn" class="hwb-action-btn">
-                        分析
+                        検索
                     </button>
                     <div id="hwb-status" class="hwb-status-info"></div>
                 </div>
                 <div id="hwb-loading" class="loading-container" style="display: none;">
-                    <p>分析中...</p>
+                    <p>読み込み中...</p>
                     <div class="loading-spinner"></div>
                 </div>
-                <div id="hwb-analysis-content"></div>
                 <div id="hwb-content">
                     <div class="card">
-                        <p>データがありません。「スキャン実行」ボタンをクリックしてください。</p>
+                        <p>データがありません。</p>
                     </div>
                 </div>
             </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -792,6 +792,14 @@ body {
     box-shadow: 0 2px 8px var(--shadow-color);
 }
 
+.hwb-ticker-input {
+    flex-grow: 1;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 5px;
+    font-size: 1em;
+}
+
 .hwb-action-btn {
     padding: 10px 20px;
     background-color: var(--tab-active-bg);
@@ -839,58 +847,43 @@ body {
     padding-bottom: 10px;
 }
 
-.hwb-summary-section {
-    margin: 15px 0;
+.hwb-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 15px;
+    margin-top: 20px;
+}
+
+.hwb-summary-grid > div {
+    text-align: center;
     padding: 15px;
     background-color: #f8f9fa;
-    border-radius: 5px;
-    border-left: 4px solid var(--tab-text);
+    border-radius: 8px;
 }
 
-.hwb-summary-section h3 {
+.hwb-summary-grid h3 {
+    margin: 0 0 10px 0;
+    font-size: 1.1em;
     color: var(--text-primary);
-    font-size: 1.2em;
-    margin-bottom: 10px;
 }
 
-.hwb-ticker-list {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 10px;
+.summary-count {
+    font-size: 2em;
+    font-weight: bold;
+    color: var(--tab-text);
+    margin: 0;
 }
 
-.hwb-ticker {
-    background-color: white;
-    padding: 5px 12px;
-    border-radius: 20px;
-    font-weight: 600;
-    font-size: 0.95em;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s;
+.hwb-search-results {
+    /* 検索結果用のスタイル */
 }
 
-.hwb-ticker:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-}
-
-.hwb-ticker.signal {
-    background-color: #d4edda;
-    color: #155724;
-    border: 1px solid #c3e6cb;
-}
-
-.hwb-ticker.candidate {
-    background-color: #d1ecf1;
-    color: #0c5460;
-    border: 1px solid #bee5eb;
-}
-
-.hwb-ticker.recent {
+.info-message {
+    padding: 15px;
     background-color: #fff3cd;
-    color: #856404;
-    border: 1px solid #ffeaa7;
+    border-left: 4px solid #ffc107;
+    border-radius: 4px;
+    margin: 15px 0;
 }
 
 .hwb-charts-section {
@@ -970,50 +963,16 @@ body {
     color: var(--text-secondary);
 }
 
-.hwb-analysis-button {
-    background-color: #007bff;
-    color: white;
-    border: none;
-    border-radius: 4px;
-    padding: 4px 8px;
-    font-size: 0.9em;
-    cursor: pointer;
-    transition: background-color 0.2s;
-}
-
-.hwb-analysis-button:hover {
-    background-color: #0056b3;
-}
-
 .hwb-chart-info span {
     display: flex;
     align-items: center;
     gap: 5px;
 }
 
-.hwb-chart-image {
+.hwb-chart-container {
     width: 100%;
-    border-radius: 5px;
+    height: 300px;
     margin-top: 10px;
-}
-
-#hwb-progress {
-    margin-top: 20px;
-    background-color: #e0e0e0;
-    border-radius: 10px;
-    overflow: hidden;
-    height: 20px;
-}
-
-.hwb-progress-bar {
-    background-color: var(--tab-text);
-    height: 100%;
-    transition: width 0.3s ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: white;
-    font-size: 0.85em;
 }
 
 @media (max-width: 768px) {
@@ -1030,200 +989,4 @@ body {
         text-align: center;
         margin-top: 10px;
     }
-}
-
-/* Analysis Modal Styles */
-.hwb-analysis-modal {
-    position: fixed;
-    z-index: 1001;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.6);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.hwb-modal-content {
-    background-color: #fefefe;
-    margin: auto;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 90%;
-    max-width: 1200px;
-    border-radius: 8px;
-    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
-}
-
-.hwb-modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px solid #ddd;
-    padding-bottom: 10px;
-    margin-bottom: 15px;
-}
-
-.hwb-modal-header h2 {
-    margin: 0;
-    color: var(--tab-text);
-}
-
-.hwb-modal-close {
-    color: #aaa;
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
-    border: none;
-    background: none;
-    cursor: pointer;
-}
-
-.hwb-modal-close:hover,
-.hwb-modal-close:focus {
-    color: black;
-    text-decoration: none;
-    cursor: pointer;
-}
-
-.hwb-modal-body {
-    width: 100%;
-    height: 70vh;
-}
-
-.hwb-analysis-info {
-    padding: 20px;
-    background-color: #f8f9fa;
-    border-radius: 8px;
-    margin-bottom: 20px;
-}
-
-.hwb-analysis-info h3 {
-    margin-top: 0;
-    color: var(--tab-text);
-}
-
-.analysis-stats {
-    display: flex;
-    gap: 30px;
-    margin: 15px 0;
-}
-
-.stat-item {
-    display: flex;
-    flex-direction: column;
-    gap: 5px;
-}
-
-.stat-label {
-    font-size: 0.9em;
-    color: var(--text-secondary);
-}
-
-.stat-value {
-    font-size: 1.5em;
-    font-weight: bold;
-    color: var(--text-primary);
-}
-
-.stat-value.signal {
-    color: #28a745;
-}
-
-.info-message {
-    padding: 10px;
-    background-color: #fff3cd;
-    border-left: 4px solid #ffc107;
-    border-radius: 4px;
-    margin: 10px 0;
-}
-
-.analysis-details {
-    margin-top: 15px;
-}
-
-.analysis-details h4 {
-    margin-bottom: 10px;
-    color: var(--text-primary);
-}
-
-.analysis-details ul {
-    list-style: none;
-    padding-left: 0;
-}
-
-.analysis-details li {
-    padding: 5px 0;
-    font-size: 0.95em;
-}
-
-.hwb-chart-container-large {
-    width: 100%;
-    height: 600px;
-    margin-top: 20px;
-}
-
-/* Analysis Modal Styles */
-.hwb-analysis-modal {
-    position: fixed;
-    z-index: 1001;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.6);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.hwb-modal-content {
-    background-color: #fefefe;
-    margin: auto;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 90%;
-    max-width: 1200px;
-    border-radius: 8px;
-    box-shadow: 0 5px 15px rgba(0,0,0,0.3);
-}
-
-.hwb-modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px solid #ddd;
-    padding-bottom: 10px;
-    margin-bottom: 15px;
-}
-
-.hwb-modal-header h2 {
-    margin: 0;
-    color: var(--tab-text);
-}
-
-.hwb-modal-close {
-    color: #aaa;
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
-    border: none;
-    background: none;
-    cursor: pointer;
-}
-
-.hwb-modal-close:hover,
-.hwb-modal-close:focus {
-    color: black;
-    text-decoration: none;
-    cursor: pointer;
-}
-
-.hwb-modal-body {
-    width: 100%;
-    height: 70vh;
 }


### PR DESCRIPTION
Refactors the HWB 200MA tab to provide a more streamlined user experience.

Backend (`hwb_scanner.py`):
- The daily summary is now structured into three categories:
  1. "当日ブレイクアウト" (Today's Breakouts)
  2. "直近5営業日以内" (Within Last 5 Business Days)
  3. "監視銘柄" (Watchlist Candidates)
- Date calculations now correctly use business days, excluding weekends.
- Watchlist candidates (active FVGs) are now sourced from the last 5 business days.

Frontend (`app.js`, `index.html`, `style.css`):
- Removes the modal-based detailed analysis view.
- Implements a direct ticker search on the main HWB tab. Search results are displayed in the main content area.
- A "Reset" button is provided to return from search results to the main summary view.
- The summary view is updated to display the new three-category layout.
- HTML and CSS have been adjusted to support the new layout, and obsolete styles have been removed.