### PR TITLE
fix(notification): 200MAスキャン通知のバグ修正と改善

### DIFF
--- a/backend/data_fetcher.py
+++ b/backend/data_fetcher.py
@@ -1596,7 +1596,7 @@ class MarketDataFetcher:
             for sub_id, subscription in list(subscriptions.items()):
                 permission = subscription.get("permission", "standard")
 
-                if is_hwb_scan_notification and permission != "secret":
+                if is_hwb_scan_notification and permission not in ["secret", "ura"]:
                     logger.info(f"Skipping HWB notification for {sub_id} due to '{permission}' permission.")
                     continue
 

--- a/backend/hwb_scanner_cli.py
+++ b/backend/hwb_scanner_cli.py
@@ -34,7 +34,7 @@ async def main():
             fetcher = MarketDataFetcher()
             
             notification_data = {
-                "title": "HWBスキャン完了",
+                "title": "200MAスキャン完了",
                 "body": f"当日: {signals_today_count}件 | 直近: {signals_recent_count}件 | 監視: {candidates_count}件",
                 "type": "hwb-scan"
             }

--- a/backend/main.py
+++ b/backend/main.py
@@ -359,7 +359,7 @@ async def trigger_hwb_scan(current_user: str = Depends(get_current_user)):
 
         return {
             "success": True,
-            "message": f"スキャン完了: {result['summary']['today_signals']}件のシグナル検出",
+            "message": f"スキャン完了: {result['summary']['signals_today_count']}件のシグナル検出",
             "scan_date": result['scan_date'],
             "scan_time": result['scan_time']
         }


### PR DESCRIPTION
200MA（HWB）スキャン完了時のプッシュ通知に関する問題を修正しました。

- 通知タイトルを「HWBスキャン完了」から「200MAスキャン完了」にユーザーの要望通り変更しました。
- 通知の対象者を、従来の'secret'権限を持つユーザーに加え、'ura'権限を持つユーザーも含まれるように修正しました。
- 関連するバグとして、手動スキャンAPI(/api/hwb/scan)がスキャン結果のキーを誤って参照していたため、KeyErrorが発生する問題を修正しました。