### PR TITLE
fix: Resolve notification race condition and add debug endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -457,6 +457,25 @@ async def analyze_ticker(ticker: str, force: bool = False, current_user: str = D
         logger.error(f"Error analyzing ticker {ticker}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"分析中に予期せぬエラーが発生しました。")
 
+@app.get("/api/debug/subscriptions")
+def debug_subscriptions(current_user: str = Depends(get_current_user)):
+    """開発用: サブスクリプションの状態を確認"""
+    subscriptions_file = os.path.join(DATA_DIR, 'push_subscriptions.json')
+    if not os.path.exists(subscriptions_file):
+        return {"status": "no_file", "subscriptions": {}}
+
+    with open(subscriptions_file, 'r') as f:
+        subs = json.load(f)
+
+    return {
+        "status": "ok",
+        "count": len(subs),
+        "subscriptions": {
+            sub_id: {"permission": data.get("permission"), "endpoint": data.get("endpoint", "")[:50]}
+            for sub_id, data in subs.items()
+        }
+    }
+
 # Mount the frontend directory to serve static files
 # This must come AFTER all API routes
 app.mount("/", StaticFiles(directory=FRONTEND_DIR, html=True), name="static")


### PR DESCRIPTION
Implements a robust fix for the push notification race condition using `async/await` to ensure proper execution order during authentication and dashboard initialization.

Frontend (`frontend/app.js`):
- Replaced the flawed `setTimeout` workaround with a correct `async/await` chain across `initializeApp`, `handleAuthSubmit`, and `showDashboard`.
- This guarantees that the authentication token is saved before the notification subscription process begins.
- Implemented a singleton pattern for `NotificationManager` to prevent multiple initializations.
- Enhanced `sendSubscriptionToServer` with authentication checks and user-facing alerts for success or failure.
- Added a one-time cleanup script in `initializeApp` to clear old authentication data and service workers for existing users, preventing migration issues.

Backend (`backend/main.py`):
- Added a `/api/debug/subscriptions` endpoint to provide developers with a way to inspect the current state of push notification subscriptions.