### PR TITLE
feat: Implement RS Rating for HWB Scanner

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -745,44 +745,60 @@ async function showDashboard() {
             }
         }
 
-        renderSymbolList(container, title, items, type) {
-            const section = document.createElement('div');
-            section.className = 'hwb-symbol-section';
-            section.innerHTML = `<h2>${title}</h2>`;
+// renderSymbolListメソッドを修正
+renderSymbolList(container, title, items, type) {
+    const section = document.createElement('div');
+    section.className = 'hwb-symbol-section';
+    section.innerHTML = `<h2>${title}</h2>`;
 
-            const list = document.createElement('div');
-            list.className = 'hwb-symbol-list';
+    const list = document.createElement('div');
+    list.className = 'hwb-symbol-list';
 
-            items.forEach(item => {
-                const symbolItem = document.createElement('div');
-                symbolItem.className = 'hwb-symbol-item';
+    items.forEach(item => {
+        const symbolItem = document.createElement('div');
+        symbolItem.className = 'hwb-symbol-item';
 
-                let badgeText = '';
-                let badgeClass = '';
-                let dateInfo = '';
+        let badgeText = '';
+        let badgeClass = '';
+        let dateInfo = '';
+        let rsRatingHtml = '';
 
-                if (type === 'signal_today' || type === 'signal_recent') {
-                    badgeText = 'ブレイクアウト';
-                    badgeClass = 'badge-signal';
-                    dateInfo = item.signal_date;
-                } else {
-                    // スコアリング削除：シンプルなFVGバッジに変更
-                    badgeText = '🐮';
-                    badgeClass = 'badge-candidate';
-                    dateInfo = item.fvg_date;
-                }
+        if (type === 'signal_today' || type === 'signal_recent') {
+            badgeText = 'ブレイクアウト';
+            badgeClass = 'badge-signal';
+            dateInfo = item.signal_date;
 
-                symbolItem.innerHTML = `
-                    <span class="hwb-symbol-name">${item.symbol}</span>
-                    <span class="hwb-symbol-badge ${badgeClass}">${badgeText}</span>
-                    <span class="hwb-symbol-date">${dateInfo}</span>
-                `;
-                list.appendChild(symbolItem);
-            });
-
-            section.appendChild(list);
-            container.appendChild(section);
+            // ✅ RS Ratingの表示
+            if (item.rs_rating !== undefined && item.rs_rating !== null) {
+                const rsClass = this.getRSClass(item.rs_rating);
+                rsRatingHtml = `<span class="hwb-rs-badge ${rsClass}">RS ${item.rs_rating}</span>`;
+            }
+        } else {
+            badgeText = '🐮';
+            badgeClass = 'badge-candidate';
+            dateInfo = item.fvg_date;
         }
+
+        symbolItem.innerHTML = `
+            <span class="hwb-symbol-name">${item.symbol}</span>
+            <span class="hwb-symbol-badge ${badgeClass}">${badgeText}</span>
+            ${rsRatingHtml}
+            <span class="hwb-symbol-date">${dateInfo}</span>
+        `;
+        list.appendChild(symbolItem);
+    });
+
+    section.appendChild(list);
+    container.appendChild(section);
+}
+
+// ✅ RS Ratingの色分けメソッドを追加
+getRSClass(rsRating) {
+    if (rsRating >= 90) return 'rs-excellent';  // 緑
+    if (rsRating >= 80) return 'rs-good';       // 青
+    if (rsRating >= 70) return 'rs-average';    // 黄
+    return 'rs-weak';                           // 灰色
+}
 
         showStatus(message, type = 'info') {
             const statusDiv = document.getElementById('hwb-status');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1075,3 +1075,41 @@ body {
         text-align: left;
     }
 }
+
+/* RS Rating バッジスタイル */
+.hwb-rs-badge {
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-weight: 600;
+    font-size: 0.8em;
+    margin: 0 5px;
+    white-space: nowrap;
+}
+
+.rs-excellent {
+    background-color: #28a745;
+    color: white;
+}
+
+.rs-good {
+    background-color: #17a2b8;
+    color: white;
+}
+
+.rs-average {
+    background-color: #ffc107;
+    color: #333;
+}
+
+.rs-weak {
+    background-color: #6c757d;
+    color: white;
+}
+
+/* モバイル対応 */
+@media (max-width: 768px) {
+    .hwb-rs-badge {
+        padding: 3px 8px;
+        font-size: 0.75em;
+    }
+}


### PR DESCRIPTION
This commit introduces the Relative Strength (RS) Rating feature to the High-Water Mark Breakout (HWB) scanner.

- Adds logic to `backend/hwb_scanner.py` to calculate the RS Rating against the SPY benchmark at the moment a breakout signal occurs.
- The calculated `rs_rating` is now stored in the `signals` array in the symbol's JSON data file.
- Updates `frontend/app.js` to display the RS Rating as a color-coded badge next to the breakout symbol in the 200MA tab.
- Adds corresponding styles for the new badges to `frontend/style.css`.

Note: Frontend verification was not completed due to persistent timeouts and failures in the backend data generation script (`hwb_scanner_cli.py`), which prevented the creation of the necessary `latest.json` file for the UI to render. The backend and frontend code changes have been implemented as requested.