### PR TITLE
Update 200MA Tab Layout and Formatting

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -715,15 +715,15 @@ async function showDashboard() {
                 </div>
                 <div class="hwb-summary-grid">
                     <div>
-                        <h3>🚀 当日ブレイクアウト</h3>
+                        <h3>当日ブレイクアウト</h3>
                         <p class="summary-count">${todayCount}</p>
                     </div>
                     <div>
-                        <h3>📈 直近5営業日</h3>
+                        <h3>直近5営業日</h3>
                         <p class="summary-count">${recentCount}</p>
                     </div>
                     <div>
-                        <h3>📍 監視銘柄</h3>
+                        <h3>監視銘柄</h3>
                         <p class="summary-count">${candidatesCount}</p>
                     </div>
                 </div>
@@ -735,13 +735,13 @@ async function showDashboard() {
             const { signals_today = [], signals_recent = [], candidates = [] } = this.summaryData.summary;
 
             if (signals_today.length > 0) {
-                this.renderSymbolList(container, '🚀 当日ブレイクアウト', signals_today, 'signal_today');
+                this.renderSymbolList(container, '当日ブレイクアウト', signals_today, 'signal_today');
             }
             if (signals_recent.length > 0) {
-                this.renderSymbolList(container, '📈 直近5営業日以内', signals_recent, 'signal_recent');
+                this.renderSymbolList(container, '直近5営業日以内', signals_recent, 'signal_recent');
             }
             if (candidates.length > 0) {
-                this.renderSymbolList(container, '📍 監視銘柄', candidates, 'candidate');
+                this.renderSymbolList(container, '監視銘柄', candidates, 'candidate');
             }
         }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -849,7 +849,7 @@ body {
 
 .hwb-summary-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 15px;
     margin-top: 20px;
 }
@@ -863,7 +863,7 @@ body {
 
 .hwb-summary-grid h3 {
     margin: 0 0 10px 0;
-    font-size: 1.1em;
+    font-size: 0.9em;
     color: var(--text-primary);
 }
 


### PR DESCRIPTION
- Remove emojis from stock count section titles (当日ブレイクアウト, 直近5営業日, 監視銘柄)
- Reduce h3 font size from 1.1em to 0.9em for better readability
- Change grid layout from 2 columns to 3 columns fixed layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)