### PR TITLE
Fix: Correctly format volume percentage display

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -828,7 +828,8 @@ renderSymbolList(container, title, items, type) {
             // 出来高増加率の表示
             if (item.volume_increase_pct !== undefined && item.volume_increase_pct !== null) {
                 const volClass = this.getVolumeClass(item.volume_increase_pct);
-                volumeHtml = `<span class="hwb-volume-badge ${volClass}">Vol +${item.volume_increase_pct}%</span>`;
+                const sign = item.volume_increase_pct > 0 ? '+' : '';
+                volumeHtml = `<span class="hwb-volume-badge ${volClass}">Vol ${sign}${item.volume_increase_pct}%</span>`;
             }
         } else {
             // 監視銘柄の日付フォーマットも変更


### PR DESCRIPTION
The volume percentage in the 200MA tab was incorrectly displaying "+-" for negative values. This commit corrects the formatting to ensure that a "+" is only added for positive values, and negative values are displayed with a single "-" sign.